### PR TITLE
adds .npmignore file so npm can use files in the gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 config/config.json
 ## WARNING: lambda.json needs to stay out of .gitignore
 ## or it won't be uploaded by claudia
-config/lambda.json
 claudia.json
 nginx/htpasswd
 *~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sharebandit",
   "version": "0.8.0",
+  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
use an .npmignore file so npm can use files mentioned in the .gitignore

marks the repo as private because if the project were published to npm, it would be packaged following the .npmignore file and not the .gitignore. The private attribute keeps someone from publishing. 